### PR TITLE
Support floating-point minimum code coverage inputs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mattpolzin2/swift-test-codecov:0.12.0
+FROM mattpolzin2/swift-test-codecov:0.13.0
 
 # WORKDIR /github/workspace
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ For example,
 jobs:
   codecov:
     container:
-      image: swift:5.3
+      image: swift:5.7
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: swift test --enable-test-discovery --enable-code-coverage
-    - uses: mattpolzin/swift-codecov-action@0.7.3
+    - uses: mattpolzin/swift-codecov-action@0.7.4
       with:
         MINIMUM_COVERAGE: 98
         INCLUDE_TESTS: 'true'
@@ -26,14 +26,16 @@ jobs:
 
 Note that you must execute your project's tests using `swift test` with the `--enable-code-coverage` argument to generate the file ingested by this action.
 
+All boolean inputs below must be specified as strings (be sure to put them in quotes in your YAML file).
+
 Inputs:
 - `PROJECT_NAME`: The name of the target project. This must be specified if you would like local dependencies (specified by path in the project manifest) to be left out of coverage numbers. If specified, this must be exactly the same spelling as the root folder of the target project.
 - `CODECOV_JSON`: The location of the JSON file produced by swift test `--enable-code-coverage`. By default `.build/debug/codecov/*.json`.
-- `MINIMUM_COVERAGE`: By default, there is no minimum coverage. Set this to make the script fail if the minimum coverage is not met.
-- `PRINT_STDOUT`: `true` by default, but if `false` then will not output the whole codecov table to stdout.
+- `MINIMUM_COVERAGE`: By default, there is no minimum coverage. Set this to a percentage (floating point number between 0.0 and 100.0) to make the script fail if the minimum coverage is not met.
+- `PRINT_STDOUT`: `'true'` by default, but if `'false'` then will not output the whole codecov table to stdout.
 - `SORT_ORDER`: `filename` by default. Determines the sort order of the code coverage table. Possible values: `filename`, `+cov`, `-cov`.
-- `INCLUDE_DEPENDENCIES`: `false` by default, but if `true` then coverage numbers will include project dependencies.
-- `INCLUDE_TESTS`: `false` by default, but if `true` then coverage numbers will include the percentage of the test files themselves that was exercised.
+- `INCLUDE_DEPENDENCIES`: `'false'` by default, but if `'true'` then coverage numbers will include project dependencies.
+- `INCLUDE_TESTS`: `'false'` by default, but if `'true'` then coverage numbers will include the percentage of the test files themselves that was exercised.
 
 Outputs:
 - `CODECOV`: Overall code coverage percentage.


### PR DESCRIPTION
Before, `MINIMUM_COVERAGE: 95.3` would have failed because `swift-test-codecov` only supported integer values for minimum code coverages. Now, floating point values are supported.